### PR TITLE
fix(hwaro): build benchmark binary with -Dpreview_mt for release parity

### DIFF
--- a/docker/Dockerfile.hwaro
+++ b/docker/Dockerfile.hwaro
@@ -19,9 +19,11 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Clone and build hwaro
+# `-Dpreview_mt` matches hwaro's official Dockerfile and release binaries;
+# without it the build runs single-threaded.
 RUN git clone https://github.com/hahwul/hwaro.git . && \
     shards install --production && \
-    shards build --release --no-debug --production
+    shards build --release --no-debug --production -Dpreview_mt
 
 ##= RUNNER =##
 FROM debian:13-slim


### PR DESCRIPTION
## Summary

The hwaro benchmark image builds with `shards build --release --no-debug --production` — without `-Dpreview_mt`. That flag is what enables Crystal's multi-threaded runtime, and hwaro's own [official Dockerfile](https://github.com/hahwul/hwaro/blob/main/docker/Dockerfile) and release workflow have shipped `-Dpreview_mt` binaries since hwaro@d101855 (2026-05-16). This Dockerfile predates that change, so every published run has measured a **single-threaded** hwaro against multi-threaded competitors (Zola's rayon uses all 4 runner vCPUs).

This PR adds the flag so the benchmark measures the binary users actually install.

## Notes
- No `CRYSTAL_WORKERS` override needed: the preview_mt default (4 threads) matches ubuntu-latest's 4 vCPUs.
- Output is unaffected — hwaro's build output is deterministic across ST/MT (verified upstream with `diff -r` on generated trees).