### PR TITLE
fix(hwaro): unbreak the image for hwaro releases after v0.18.1

### DIFF
--- a/docker/Dockerfile.hwaro
+++ b/docker/Dockerfile.hwaro
@@ -9,7 +9,7 @@
 
 ##= BUILDER =##
 # Keep in sync with docker/versions.env.
-ARG CRYSTAL_IMAGE=84codes/crystal:1.20.3-debian-13
+ARG CRYSTAL_IMAGE=84codes/crystal:1.21.0-debian-13
 FROM ${CRYSTAL_IMAGE} AS builder
 
 LABEL maintainer="SSG Benchmark"
@@ -27,13 +27,34 @@ RUN apt-get update && \
     git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Clone the pinned release and build it.
-# `-Dpreview_mt` matches hwaro's official Dockerfile and release binaries;
-# without it the build runs single-threaded.
+# Clone the pinned release and build it the way that release ships.
+#
+# Hwaro changed how it gets its parallelism, and the two eras need opposite
+# build flags — passing the wrong one is not a slow build, it is a hard error
+# or a silently single-threaded one, so the flag is derived from the pinned
+# tag's own source rather than hand-maintained alongside HWARO_VERSION:
+#
+#   <= v0.18.1  parallelism came from `-Dpreview_mt`. Without the flag these
+#               releases run single-threaded (no execution-context resize
+#               exists in their source), which would understate them.
+#   >  v0.18.1  `-Dpreview_mt` was dropped (it is deprecated in Crystal 1.21
+#               and its legacy scheduler can hang at process exit). `src/main.cr`
+#               resizes the default execution context instead, and that API does
+#               not exist under the flag — building with it fails outright with
+#               `undefined constant Fiber::ExecutionContext`.
+#
+# The same cutover is why CRYSTAL_IMAGE must stay >= 1.21: releases after
+# v0.18.1 declare `crystal: ">= 1.21.0"` and reference an API 1.20 lacks.
 RUN git clone --depth 1 --branch "${HWARO_VERSION}" https://github.com/hahwul/hwaro.git . && \
     git rev-parse HEAD > /hwaro/.build-commit && \
     shards install --production && \
-    shards build --release --no-debug --production -Dpreview_mt
+    if grep -q 'Fiber::ExecutionContext' src/main.cr; then \
+        echo "execution contexts: building without -Dpreview_mt" && \
+        shards build --release --no-debug --production; \
+    else \
+        echo "legacy MT: building with -Dpreview_mt" && \
+        shards build --release --no-debug --production -Dpreview_mt; \
+    fi
 
 ##= RUNNER =##
 # Must stay on the same Debian release as the builder: the binary links against

--- a/docker/versions.env
+++ b/docker/versions.env
@@ -27,7 +27,7 @@ PYTHON_IMAGE=python:3.12-slim-bookworm
 # --- Build-only toolchains (source-built SSGs) ---
 RUST_IMAGE=rust:1.83-slim-bookworm
 # hwaro's runner stage must stay on debian:13-slim to match this builder's glibc.
-CRYSTAL_IMAGE=84codes/crystal:1.20.3-debian-13
+CRYSTAL_IMAGE=84codes/crystal:1.21.0-debian-13
 
 # --- Compiled SSGs ---
 # Hugo: pinned below 0.146.0 on purpose. 0.146 removed layouts/_default and


### PR DESCRIPTION
## The problem

Bumping `HWARO_VERSION` past `v0.18.1` fails the image build outright today, for two independent reasons. Both are reproducible right now:

**1. `-Dpreview_mt` is hardcoded.** Hwaro dropped that flag after v0.18.1 — it is deprecated in Crystal 1.21 and its legacy scheduler can hang at process exit — and `src/main.cr` resizes the default execution context instead. That API does not exist under the flag:

```
$ crystal build src/main.cr -Dpreview_mt      # hwaro main
In src/main.cr:121:1
 121 | Fiber::ExecutionContext.default.resize(Fiber::ExecutionContext.default_workers_count)
       ^----------------------
Error: undefined constant Fiber::ExecutionContext
```

**2. `CRYSTAL_IMAGE` is pinned to 1.20.3**, which does not have `Fiber::ExecutionContext` either:

```
$ docker run --rm 84codes/crystal:1.20.3-debian-13 ... crystal run
Error: undefined constant Fiber::ExecutionContext
```

Hwaro after v0.18.1 declares `crystal: ">= 1.21.0"`.

## Why not just delete the flag

v0.18.1 and earlier have no execution-context resize in their source, so without `-Dpreview_mt` they build **single-threaded** and the benchmark would understate them — the mirror image of the v1 fairness bug this repo already fixed once.

The two eras need opposite flags, so the flag is derived from the pinned tag's own source rather than hand-maintained next to `HWARO_VERSION`. A version bump stays a one-line change and cannot silently pick the wrong build mode in either direction.

## Verification

Both eras build correctly with this Dockerfile:

```
v0.18.1 → legacy MT: building with -Dpreview_mt
main    → execution contexts: building without -Dpreview_mt
```

All three scenarios were then run at 1000 pages against both images (`--cpus=4 --memory=4g --network=none`, interleaved, median of 7). Output file counts match the parity guard — minimal 1002, blog/heavy 1113 for both:

| scenario | v0.18.1 | post-0.18.1 | delta |
|---|---|---|---|
| minimal | 615ms | 616ms | +0.2% |
| blog | 912ms | 785ms | −13.9% |
| heavy | 1619ms | 1657ms | +2.3% |

This PR changes only the build; no site config, scenario, or methodology is touched.

## Note on `HWARO_VERSION`

Left at `v0.18.1` on purpose. This PR only makes the *next* bump possible — it does not track main, per the Dockerfile's existing fairness note.